### PR TITLE
Update ed25519_test.go

### DIFF
--- a/golang/examples/bip32_test.go
+++ b/golang/examples/bip32_test.go
@@ -588,7 +588,7 @@ func Example_bip32_KeyDerivation() {
 		),
 		BaseKey: publicKey,
 	}
-	_, err := cryptoClient.DeriveKey(context.Background(), deriveKeyRequestPub)
+	_, err = cryptoClient.DeriveKey(context.Background(), deriveKeyRequestPub)
 	if err != nil {
 		fmt.Println("Don't supporte deriving key from pulic -> public in current soft-hsm version")
 	} else {

--- a/golang/examples/bip32_test.go
+++ b/golang/examples/bip32_test.go
@@ -592,7 +592,7 @@ func Example_bip32_KeyDerivation() {
 	if err != nil {
 		fmt.Println("Don't supporte deriving key from pulic -> public in current soft-hsm version")
 	} else {
-		fmt.Printf("Derive key from public to public successfully %v", deriveKeyResponsePub)
+		fmt.Printf("Derive key from public to public successfully")
 	}
 
 	// Output:
@@ -604,7 +604,7 @@ func Example_bip32_KeyDerivation() {
 	// Derived Key type=CkBIP0032PRV2PUB index=0
 	// Derive key from private -> public
 	// Derive key from private -> private
-	// Don't supporte deriving key from pulic -> public in current soft-hsm version
+	// Derive key from public to public successfully
 }
 
 //cross sign and verification

--- a/golang/examples/bip32_test.go
+++ b/golang/examples/bip32_test.go
@@ -588,7 +588,7 @@ func Example_bip32_KeyDerivation() {
 		),
 		BaseKey: publicKey,
 	}
-	deriveKeyResponsePub, err := cryptoClient.DeriveKey(context.Background(), deriveKeyRequestPub)
+	_, err := cryptoClient.DeriveKey(context.Background(), deriveKeyRequestPub)
 	if err != nil {
 		fmt.Println("Don't supporte deriving key from pulic -> public in current soft-hsm version")
 	} else {

--- a/golang/examples/ed25519_test.go
+++ b/golang/examples/ed25519_test.go
@@ -432,17 +432,17 @@ func TestED25519InvalidKeyType(t *testing.T) {
 	signature, err := ed25519KeySignSingle(t, cryptoClient, generateKeyPairResponseECDSA.PrivKeyBytes, signData)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "SignSingle error")
-	assert.Contains(t, err.Error(), "CKR_MECHANISM_INVALID")
+	assert.Contains(t, err.Error(), "CKR_KEY_TYPE_INCONSISTENT")
 
 	signature, err = ed25519KeySign(t, cryptoClient, generateKeyPairResponseECDSA.PrivKeyBytes, signData)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "SignInit error")
-	assert.Contains(t, err.Error(), "CKR_MECHANISM_INVALID")
+	assert.Contains(t, err.Error(), "CKR_KEY_TYPE_INCONSISTENT")
 
 	signature, err = ed25519KeySignMulti(t, cryptoClient, generateKeyPairResponseECDSA.PrivKeyBytes, signData)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "SignInit error")
-	assert.Contains(t, err.Error(), "CKR_MECHANISM_INVALID")
+	assert.Contains(t, err.Error(), "CKR_KEY_TYPE_INCONSISTENT")
 
 	// Verify with the wrong key type
 	generateKeyPairResponseED25519, err := ed25519KeyGenerate(t, cryptoClient)
@@ -457,12 +457,12 @@ func TestED25519InvalidKeyType(t *testing.T) {
 	err = ed25519KeyVerify(t, cryptoClient, generateKeyPairResponseECDSA.PubKeyBytes, signData, signature)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "VerifyInit error")
-	assert.Contains(t, err.Error(), "CKR_MECHANISM_INVALID")
+	assert.Contains(t, err.Error(), "CKR_KEY_TYPE_INCONSISTENT")
 
 	err = ed25519KeyVerifyMulti(t, cryptoClient, generateKeyPairResponseECDSA.PubKeyBytes, signData, signature)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "VerifyInit error")
-	assert.Contains(t, err.Error(), "CKR_MECHANISM_INVALID")
+	assert.Contains(t, err.Error(), "CKR_KEY_TYPE_INCONSISTENT")
 }
 
 func TestED25519InvalidKeys(t *testing.T) {


### PR DESCRIPTION
change error code from CKR_MECHANISM_INVALID to CKR_KEY_TYPE_INCONSISTENT for latest grep11 build.
```
[2022-02-16T02:44:31.451Z] === RUN   TestED25519InvalidKeyType

[2022-02-16T02:44:31.451Z]     ed25519_test.go:397: Testing GenerateKeyPair(), Generated ECDSA PKCS key pair for negative test

[2022-02-16T02:44:31.451Z]     ed25519_test.go:435: 

[2022-02-16T02:44:31.451Z]         	Error Trace:	ed25519_test.go:435

[2022-02-16T02:44:31.451Z]         	Error:      	"SignSingle error: rpc error: code = Unknown desc = Unexpected error (CKR_KEY_TYPE_INCONSISTENT)" does not contain "CKR_MECHANISM_INVALID"

[2022-02-16T02:44:31.451Z]         	Test:       	TestED25519InvalidKeyType

[2022-02-16T02:44:31.451Z]     ed25519_test.go:440: 

[2022-02-16T02:44:31.451Z]         	Error Trace:	ed25519_test.go:440

[2022-02-16T02:44:31.451Z]         	Error:      	"SignInit error: rpc error: code = Unknown desc = Unexpected error (CKR_KEY_TYPE_INCONSISTENT)" does not contain "CKR_MECHANISM_INVALID"

[2022-02-16T02:44:31.451Z]         	Test:       	TestED25519InvalidKeyType

[2022-02-16T02:44:31.451Z]     ed25519_test.go:445: 

[2022-02-16T02:44:31.451Z]         	Error Trace:	ed25519_test.go:445

[2022-02-16T02:44:31.451Z]         	Error:      	"SignInit error: rpc error: code = Unknown desc = Unexpected error (CKR_KEY_TYPE_INCONSISTENT)" does not contain "CKR_MECHANISM_INVALID"

[2022-02-16T02:44:31.451Z]         	Test:       	TestED25519InvalidKeyType

[2022-02-16T02:44:31.451Z]     ed25519_test.go:189: Testing GenerateKeyPair(), Generated ED25519 PKCS key pair

[2022-02-16T02:44:31.451Z]     ed25519_test.go:204: Testing SignSingle(), Data signed by using SignSingle() with ED25519 PKCS key pair

[2022-02-16T02:44:31.451Z]     ed25519_test.go:460: 

[2022-02-16T02:44:31.451Z]         	Error Trace:	ed25519_test.go:460

[2022-02-16T02:44:31.451Z]         	Error:      	"VerifyInit error: rpc error: code = Unknown desc = Unexpected error (CKR_KEY_TYPE_INCONSISTENT)" does not contain "CKR_MECHANISM_INVALID"

[2022-02-16T02:44:31.451Z]         	Test:       	TestED25519InvalidKeyType

[2022-02-16T02:44:31.451Z]     ed25519_test.go:465: 

[2022-02-16T02:44:31.451Z]         	Error Trace:	ed25519_test.go:465

[2022-02-16T02:44:31.451Z]         	Error:      	"VerifyInit error: rpc error: code = Unknown desc = Unexpected error (CKR_KEY_TYPE_INCONSISTENT)" does not contain "CKR_MECHANISM_INVALID"

[2022-02-16T02:44:31.451Z]         	Test:       	TestED25519InvalidKeyType

[2022-02-16T02:44:31.451Z] --- FAIL: TestED25519InvalidKeyType (1.96s)
```
The error log is like this. Seems it has supported "Public to Pulblic".
```
[2022-02-16T02:45:18.408Z] Derive key from public to public successfully NewKeyBytes:"0V0\020\006\007*\206H\316=\002\001\006\005+\201\004\000\n\003B\000\004=:?\272\227\005?\253mU\234\234\264\016\035\211\201\257\330h}\036b?\223\262\032:\350\371\342\027[\177\016\261\033\214\271q\214\032\021\017\354\313^D\303`6\213I\275*\365\330?\373#\211;\325Z\004\020\325r\273\251B\330\240\301n\000\306\217\231\020k\342\004 \000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\004\010\246\275l\356\203Gr\253\004\010\000\000\000\000\000\000\000\001\0044\020\003\020\004\000@\220\202\000@\220\202\200\001\000\n\000\000\000\001\000\000\001\000\000\000\000\003\000\000\001a\000\000\000\000\000\000\001\200\000\000\000\007\006\005+\201\004\000\n\000\004 @>\360\364\035\035\233\245\324\325\212\350\307E\317\253\247&8q\240\313\2224\315\024\333\033\271G,\010" CheckSum:"|\341h\352V\363O]\371\237\357\3668 \n\352 #b\372OqU\241BhMB\221\016\3444" NewKey:<KeyBlobID:"kx.\007\362hD-\244\2523\314cX\016\356" TxID:"\315\320\263\3717\201C\033\201\306\262\326\324\233\230A" Attributes:<key:CKA_TRUSTED value:<AttributeTF:false > > Attributes:<key:CKA_CHECK_VALUE value:<AttributeB:"|\341h" > > Attributes:<key:CKA_KEY_TYPE value:<AttributeI:3 > > Attributes:<key:CKA_ENCRYPT value:<AttributeTF:false > > Attributes:<key:CKA_DECRYPT value:<AttributeTF:false > > Attributes:<key:CKA_WRAP value:<AttributeTF:false > > Attributes:<key:CKA_UNWRAP value:<AttributeTF:false > > Attributes:<key:CKA_SIGN value:<AttributeTF:false > > Attributes:<key:CKA_SIGN_RECOVER value:<AttributeTF:false > > Attributes:<key:CKA_VERIFY value:<AttributeTF:true > > Attributes:<key:CKA_VERIFY_RECOVER value:<AttributeTF:false > > Attributes:<key:CKA_DERIVE value:<AttributeTF:true > > Attributes:<key:CKA_VALUE_LEN value:<AttributeI:0 > > Attributes:<key:CKA_EXTRACTABLE value:<AttributeTF:false > > Attributes:<key:CKA_LOCAL value:<AttributeTF:false > > Attributes:<key:CKA_NEVER_EXTRACTABLE value:<AttributeTF:true > > Attributes:<key:CKA_KEY_GEN_MECHANISM value:<AttributeI:2147942401 > > Attributes:<key:CKA_MODIFIABLE value:<AttributeTF:false > > Attributes:<key:CKA_EC_PARAMS value:<AttributeB:"\006\005+\201\004\000\n" > > Attributes:<key:CKA_WRAP_WITH_TRUSTED value:<AttributeTF:false > > Attributes:<key:CKA_IBM_USE_AS_DATA value:<AttributeTF:true > > KeyBlobs:"0V0\020\006\007*\206H\316=\002\001\006\005+\201\004\000\n\003B\000\004=:?\272\227\005?\253mU\234\234\264\016\035\211\201\257\330h}\036b?\223\262\032:\350\371\342\027[\177\016\261\033\214\271q\214\032\021\017\354\313^D\303`6\213I\275*\365\330?\373#\211;\325Z\004\020\325r\273\251B\330\240\301n\000\306\217\231\020k\342\004 \000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\004\010\246\275l\356\203Gr\253\004\010\000\000\000\000\000\000\000\001\0044\020\003\020\004\000@\220\202\000@\220\202\200\001\000\n\000\000\000\001\000\000\001\000\000\000\000\003\000\000\001a\000\000\000\000\000\000\001\200\000\000\000\007\006\005+\201\004\000\n\000\004 @>\360\364\035\035\233\245\324\325\212\350\307E\317\253\247&8q\240\313\2224\315\024\333\033\271G,\010" >

[2022-02-16T02:45:18.409Z] want:

[2022-02-16T02:45:18.409Z] Generating random seed key...

[2022-02-16T02:45:18.409Z] Generating master key and master chaincode...

[2022-02-16T02:45:18.409Z] Derived Key type=CkBIP0032MASTERK index=0

[2022-02-16T02:45:18.409Z] Generated master key from random seed and master chaincode

[2022-02-16T02:45:18.409Z] Generating Wallets accounts...

[2022-02-16T02:45:18.409Z] Derived Key type=CkBIP0032PRV2PUB index=0

[2022-02-16T02:45:18.409Z] Derive key from private -> public

[2022-02-16T02:45:18.409Z] Derive key from private -> private

[2022-02-16T02:45:18.409Z] Don't supporte deriving key from pulic -> public in current soft-hsm version
```